### PR TITLE
Add chat and group chat tables with permissions

### DIFF
--- a/database/migrations/008_add_chat_tables.sql
+++ b/database/migrations/008_add_chat_tables.sql
@@ -1,0 +1,62 @@
+-- Migration: Add chat and friend request tables
+-- Created: 2025-01-10
+
+-- Changed all user ID columns from INTEGER to UUID to match users table
+
+-- Friend requests table
+CREATE TABLE IF NOT EXISTS friend_requests (
+    id SERIAL PRIMARY KEY,
+    sender_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    receiver_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'rejected')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(sender_id, receiver_id)
+);
+
+-- Friendships table (created when request is accepted)
+CREATE TABLE IF NOT EXISTS friendships (
+    id SERIAL PRIMARY KEY,
+    user1_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user2_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user1_id, user2_id),
+    CHECK (user1_id < user2_id) -- Ensure consistent ordering
+);
+
+-- Messages table
+CREATE TABLE IF NOT EXISTS messages (
+    id SERIAL PRIMARY KEY,
+    sender_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    receiver_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    message TEXT NOT NULL,
+    is_read BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_friend_requests_sender ON friend_requests(sender_id);
+CREATE INDEX IF NOT EXISTS idx_friend_requests_receiver ON friend_requests(receiver_id);
+CREATE INDEX IF NOT EXISTS idx_friend_requests_status ON friend_requests(status);
+
+CREATE INDEX IF NOT EXISTS idx_friendships_user1 ON friendships(user1_id);
+CREATE INDEX IF NOT EXISTS idx_friendships_user2 ON friendships(user2_id);
+
+CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
+CREATE INDEX IF NOT EXISTS idx_messages_receiver ON messages(receiver_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+
+-- Function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_friend_request_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for friend_requests
+CREATE TRIGGER friend_requests_updated_at
+    BEFORE UPDATE ON friend_requests
+    FOR EACH ROW
+    EXECUTE FUNCTION update_friend_request_updated_at();

--- a/database/migrations/009_add_group_chat_tables.sql
+++ b/database/migrations/009_add_group_chat_tables.sql
@@ -1,0 +1,73 @@
+-- Migration: Add Group Chat Tables
+-- Description: Creates tables for group chats and group members
+
+-- Create groups table
+CREATE TABLE IF NOT EXISTS groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create group_members table
+CREATE TABLE IF NOT EXISTS group_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(group_id, user_id)
+);
+
+-- First, drop the existing constraint if it exists, then alter the column to allow NULL
+DO $$ 
+BEGIN
+    -- Drop the NOT NULL constraint on receiver_id
+    ALTER TABLE messages ALTER COLUMN receiver_id DROP NOT NULL;
+EXCEPTION
+    WHEN others THEN
+        -- Column might already allow NULL, continue
+        NULL;
+END $$;
+
+-- Add group_id and is_group_message columns if they don't exist
+ALTER TABLE messages 
+ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES groups(id) ON DELETE CASCADE,
+ADD COLUMN IF NOT EXISTS is_group_message BOOLEAN DEFAULT FALSE;
+
+-- Drop the old constraint if it exists before adding the new one
+DO $$ 
+BEGIN
+    ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_receiver_or_group_check;
+EXCEPTION
+    WHEN others THEN
+        NULL;
+END $$;
+
+-- Add check constraint to ensure either receiver_id or group_id is set
+ALTER TABLE messages 
+ADD CONSTRAINT messages_receiver_or_group_check 
+CHECK (
+    (receiver_id IS NOT NULL AND group_id IS NULL AND is_group_message = FALSE) OR
+    (receiver_id IS NULL AND group_id IS NOT NULL AND is_group_message = TRUE)
+);
+
+-- Create indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_groups_created_by ON groups(created_by);
+CREATE INDEX IF NOT EXISTS idx_group_members_group_id ON group_members(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_members_user_id ON group_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_messages_group_id ON messages(group_id);
+
+-- Create trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_groups_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_groups_updated_at
+    BEFORE UPDATE ON groups
+    FOR EACH ROW
+    EXECUTE FUNCTION update_groups_updated_at();

--- a/database/scripts/grant_chat_permissions.sql
+++ b/database/scripts/grant_chat_permissions.sql
@@ -1,0 +1,11 @@
+-- Grant permissions for group chat tables
+
+-- Grant permissions on groups table
+GRANT SELECT, INSERT, UPDATE, DELETE ON groups TO campus_connect;
+-- Removed sequence grants since we're using UUID, not SERIAL
+
+-- Grant permissions on group_members table
+GRANT SELECT, INSERT, UPDATE, DELETE ON group_members TO campus_connect;
+-- Removed sequence grants since we're using UUID, not SERIAL
+
+-- Note: messages table permissions already granted in previous migration

--- a/database/scripts/grant_group_chat_permissions.sql
+++ b/database/scripts/grant_group_chat_permissions.sql
@@ -1,0 +1,11 @@
+-- Grant permissions for group chat tables
+
+-- Grant permissions on groups table (UUID primary key, no sequence needed)
+GRANT SELECT, INSERT, UPDATE, DELETE ON groups TO campus_connect;
+
+-- Grant permissions on group_members table (UUID primary key, no sequence needed)
+GRANT SELECT, INSERT, UPDATE, DELETE ON group_members TO campus_connect;
+
+-- Note: messages table permissions already granted in previous migration
+-- Note: groups and group_members tables use UUID primary keys (gen_random_uuid()),
+-- so there are no sequences to grant permissions on


### PR DESCRIPTION
Introduces SQL migrations for chat, friend requests, friendships, messages, group chats, and group members. Updates the messages table to support group messages, adds relevant indexes and triggers, and provides scripts to grant permissions on new tables to the campus_connect role.