### PR TITLE
Add chat attachments support to messages

### DIFF
--- a/database/migrations/010_add_chat_attachments.sql
+++ b/database/migrations/010_add_chat_attachments.sql
@@ -1,0 +1,16 @@
+-- Migration: Add attachment support to chat messages
+-- Description: Adds columns for file attachments in messages table
+
+-- Add attachment columns to messages table
+ALTER TABLE messages 
+ADD COLUMN IF NOT EXISTS attachment_path VARCHAR(500),
+ADD COLUMN IF NOT EXISTS attachment_name VARCHAR(255),
+ADD COLUMN IF NOT EXISTS attachment_size INTEGER,
+ADD COLUMN IF NOT EXISTS attachment_type VARCHAR(100);
+
+-- Add index for better query performance
+CREATE INDEX IF NOT EXISTS idx_messages_attachment ON messages(attachment_path) WHERE attachment_path IS NOT NULL;
+
+-- Add check constraint for attachment size (max 10MB)
+ALTER TABLE messages 
+ADD CONSTRAINT check_attachment_size CHECK (attachment_size IS NULL OR attachment_size <= 10485760);

--- a/database/migrations/011_allow_null_message_content.sql
+++ b/database/migrations/011_allow_null_message_content.sql
@@ -1,0 +1,10 @@
+-- Migration: Allow NULL message content for attachment-only messages
+-- Created: 2025-01-11
+
+-- Modify the messages table to allow NULL in the message column
+-- This allows users to send attachments without text content
+ALTER TABLE messages 
+ALTER COLUMN message DROP NOT NULL;
+
+-- Add a check constraint to ensure at least message or attachment exists
+-- This will be enforced at the application level since we have attachment info in a separate table

--- a/database/scripts/grant_chat_attachments_permissions.sql
+++ b/database/scripts/grant_chat_attachments_permissions.sql
@@ -1,0 +1,15 @@
+-- Grant permissions for chat attachments feature
+-- This script grants necessary permissions on the attachment columns added to messages table
+
+-- Removed reference to non-existent group_messages table
+-- Both 1-on-1 and group chat messages are stored in the messages table
+-- Updated username from campus_connect_user to campus_connect
+GRANT SELECT, INSERT, UPDATE ON messages TO campus_connect;
+
+-- Grant usage on sequences (if needed)
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO campus_connect;
+
+-- Ensure the user can access the uploads directory path
+-- Note: File system permissions should be set separately on the server
+
+COMMIT;


### PR DESCRIPTION
Introduces database migrations to add attachment columns to the messages table, allows NULL message content for attachment-only messages, and provides a script to grant necessary permissions for the new attachment features. These changes enable users to send messages with file attachments and ensure proper access control.